### PR TITLE
Location, ETD/Coaches, Ordering, Operator info

### DIFF
--- a/Src/api_client.cpp
+++ b/Src/api_client.cpp
@@ -84,7 +84,10 @@ std::string TrainAPIClient::fetchDepartures(const std::string& from, const std::
     if(!base_url_key.empty()) {
         api_header = "x-apikey:" + base_url_key;
         headers = curl_slist_append(headers, api_header.c_str());
-        DEBUG_PRINT("API header: " << api_header.c_str());
+
+        // *WARNING* uncommenting the next line means your API key is included in log/debug info.
+        //DEBUG_PRINT("API header: " << api_header.c_str());
+
         curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
     }
 

--- a/Src/config.h
+++ b/Src/config.h
@@ -29,6 +29,7 @@ private:
     const std::map<std::string, std::string> defaults = {
         {"from", ""},
         {"to", ""},
+        {"ShowLocation", ""},
         {"APIURL", ""},
         {"APIkey", ""},
         {"Rail_Data_Marketplace", ""},
@@ -47,6 +48,7 @@ private:
         {"third_line_y", "58"},
         {"fourth_line_y", "72"},
         {"third_line_refresh_seconds", "10"},
+        {"ETD_coach_refresh_seconds", "3"},
         {"ShowCallingPointETD", "Yes"},
         {"ShowMessages", "Yes"},
         {"ShowPlatforms", "Yes"},
@@ -98,4 +100,5 @@ public:
 };
 
 #endif // CONFIG_H
+
 

--- a/Src/parser_test.cpp
+++ b/Src/parser_test.cpp
@@ -266,5 +266,11 @@ int main(int argc, char* argv[]) {
         service = parser.getThirdDeparture();
         std::cout << "Third: Platform " << parser.getPlatform(service) << " at " << parser.getScheduledDepartureTime(service) << " to " << parser.getDestination(service) << std::endl;
        }
+    
+    std::cout << "==========================================================" << std::endl;
+    std::cout << "====================== Location ==========================" << std::endl;
+    std::cout << parser.getLocationName() << std::endl << std::endl;
+    
      return 0;
  }
+

--- a/Src/train_service_display.h
+++ b/Src/train_service_display.h
@@ -49,6 +49,7 @@ private:
     const Config& config;         // Traindisplay configuration object
     
     // Display state
+    enum FirstRowState { ETD, COACHES };               // Toggle to show the Estimated Time of Departure or Coaches on the 1st line
     enum ThirdRowState { SECOND_TRAIN, THIRD_TRAIN };  // Toggle to show 2nd or 3rd train on the 3rd line
     enum FourthRowState { CLOCK, MESSAGE };            // Toggle to show the Clock alone or the Clock and message on the 4th line
     
@@ -60,9 +61,11 @@ private:
     std::string third_line;            // Toggle between 2nd and 3rd departure
     std::string clock_display;         // The clock
     std::string nrcc_message;          // Network Rail messages
+    std::string location_name;         // Location name for the departure board
 
     bool show_platforms;               // Yes/No - show platforms
-    bool platform_selected;            // Yes/No - has a specific platcorm been selected
+    bool show_location;                // Yes/No - show location
+    bool platform_selected;            // Yes/No - has a specific platform been selected
     std::string selected_platform;     // The selected platform
     bool has_message;                  // Yes/No - are there messages
     bool show_messages;                // Yes/No - are messages being shown
@@ -84,9 +87,11 @@ private:
     int scroll_x_calling_points;
     int scroll_x_message;
     
-    // State - for toggle on the 3rd and 4th row
+    // State - for toggle on the 1st, 3rd and 4th row and API refresh interval
+    FirstRowState first_row_state;
     ThirdRowState third_row_state;
     FourthRowState fourth_row_state;
+    std::chrono::steady_clock::time_point last_first_row_toggle;
     std::chrono::steady_clock::time_point last_third_row_toggle;
     std::chrono::steady_clock::time_point last_fourth_row_toggle;
     std::chrono::steady_clock::time_point last_refresh;
@@ -100,8 +105,10 @@ private:
     void updateScrollPositions();
     void updateMessageScroll();
 
+    void checkFirstRowStateTransition();
     void checkThirdRowStateTransition();
     void checkFourthRowStateTransition();
+    void transitionFirstRowState();
     void transitionThirdRowState();
     void transitionFourthRowState();
 
@@ -117,3 +124,4 @@ public:
 };
 
 #endif // TRAIN_SERVICE_DISPLAY_H
+

--- a/Src/train_service_parser.h
+++ b/Src/train_service_parser.h
@@ -20,6 +20,9 @@
 #include <array>
 #include <iostream>
 #include <iomanip>
+#include <chrono>
+#include <atomic>
+#include <ctime>
 
 using json = nlohmann::json;
 
@@ -30,14 +33,15 @@ extern bool debug_mode;
 
 class TrainServiceParser {
 private:
-    json data;                             // Departure data
-    std::mutex dataMutex;                  // Process control
+    json data;                                  // Departure data
+    std::mutex dataMutex;                       // Process control
 
-    bool showCallingPointETD;              // Flag to show Estimated Time of Departure in calling points
-    bool selectPlatform;                   // Flag to indicate whether departures for a specific platform are selected
+    bool showCallingPointETD;                   // Flag to show Estimated Time of Departure in calling points
+    bool selectPlatform;                        // Flag to indicate whether departures for a specific platform are selected
 
-    std::string selected_platform;         // Store the selected platform
-    std::array<size_t, 3> ServiceList;     // Array for the 1st, 2nd and 3rd departures
+    std::string selected_platform;              // Store the selected platform
+    std::array<size_t, 3> ServiceList;          // Array for the 1st, 2nd and 3rd departures
+    std::array<size_t, 10> ETDOrderedList;      // Array of Service Indices in ETD order
 
     std::string processHtmlTags(const std::string& html);     // Helper method to strip HTML tags from text
 
@@ -48,6 +52,7 @@ public:
     void setSelectedPlatform(const std::string& platform);    // Set a specific platform - departures will be found for that platform
     void unsetSelectedPlatform();                             // Unset the selected platform - departures will be found for all platforms
     void updateData(const std::string& jsonString);           // Update with new JSON data
+    void createOrderedDepartureList();                        // Create an array of indices in order of departure time (STD and ETD - whichever is later)
     
     void findServices();                                      // Find the next 3 services - takes into account whether a specific platform has been set
 
@@ -59,19 +64,21 @@ public:
     size_t getSecondDeparture();                              // Return the index for the second departure
     size_t getThirdDeparture();                               // Return the index for the third departure
 
-    std::string getScheduledDepartureTime(size_t serviceIndex);  //Return the scheduled departure time for the selected service
-    std::string getEstimatedDepartureTime(size_t serviceIndex);  //Return the estimated departure time for the selected service
-    std::string getPlatform(size_t serviceIndex);                //Return the platform for the selected service
-    std::string getDestination(size_t serviceIndex);             //Return the destination for the selected service
-    std::string getCallingPoints(size_t serviceIndex);           //Return the calling points for the selected service
-    std::string getCoaches(size_t serviceIndex, bool addText);   //Return the number of coaches for the selected service - if addText is true then return in the "Formed of x coaches" format
-    std::string getOperator(size_t serviceIndex);                //Return the operator of the selected service
-    std::string getNrccMessages();                               //Return any Network Rail messages
+    std::string getScheduledDepartureTime(size_t serviceIndex);  // Return the scheduled departure time for the selected service
+    std::string getEstimatedDepartureTime(size_t serviceIndex);  // Return the estimated departure time for the selected service
+    std::string getPlatform(size_t serviceIndex);                // Return the platform for the selected service
+    std::string getDestination(size_t serviceIndex);             // Return the destination for the selected service
+    std::string getCallingPoints(size_t serviceIndex);           // Return the calling points for the selected service
+    std::string getCoaches(size_t serviceIndex, bool addText);   // Return the number of coaches for the selected service - if addText is true then return in the "Formed of x coaches" format
+    std::string getOperator(size_t serviceIndex);                // Return the operator of the selected service
+    std::string getNrccMessages();                               // Return any Network Rail messages
+    std::string getLocationName();                               // Return the name of the location for the departure data
     
-    std::string getDelayReason(size_t serviceIndex);  //Return the delay reason for the selected service
-    std::string getCancelReason(size_t serviceIndex); //Return the cancellation reason time for the selected service
-    std::string getadhocAlerts(size_t serviceIndex);  //Return any adhoc alerts for the selected service
+    std::string getDelayReason(size_t serviceIndex);  // Return the delay reason for the selected service
+    std::string getCancelReason(size_t serviceIndex); // Return the cancellation reason time for the selected service
+    std::string getadhocAlerts(size_t serviceIndex);  // Return any adhoc alerts for the selected service
 };
 
 #endif // TRAIN_SERVICE_PARSER_H
+
 

--- a/Src/traindisplay.cpp
+++ b/Src/traindisplay.cpp
@@ -121,12 +121,36 @@ void processCommandLineArgs(int argc, char* argv[], Config& config) {
     }
 
     // Debug output of key configuration values
-    DEBUG_PRINT("Final configuration:");
+    DEBUG_PRINT("Using configuration:");
     DEBUG_PRINT("From: " << config.get("from"));
     DEBUG_PRINT("To: " << config.get("to"));
+    DEBUG_PRINT("Selected Platform: " << config.get("platform"));
     DEBUG_PRINT("Show Calling Point ETD: " << config.getBool("ShowCallingPointETD"));
     DEBUG_PRINT("Show Messages: " << config.getBool("ShowMessages"));
     DEBUG_PRINT("Show Platforms: " << config.getBool("ShowPlatforms"));
+    DEBUG_PRINT("Show Location: " << config.getBool("ShowLocation"));
+    DEBUG_PRINT("Scroll slowdown (ms): " << config.get("scroll_slowdown_sleep_ms"));
+    DEBUG_PRINT("API URL: " << config.get("APIURL"));
+    DEBUG_PRINT("Use Raildata Marketplace (if yes/1 this will over-ride the API URL): " << config.getBool("Rail_Data_Marketplace"));
+    DEBUG_PRINT("Font Path: " << config.get("fontPath"));
+    DEBUG_PRINT("Data refresh interval (s): " << config.get("refresh_interval_seconds"));
+    DEBUG_PRINT("Message display interval (s): " << config.get("Message_Refresh_interval"));
+    DEBUG_PRINT("2nd/3rd departure toggle interval (s): " << config.get("third_line_refresh_seconds"));
+    DEBUG_PRINT("Coach/ETD displayh interval (s): " << config.get("ETD_coach_refresh_seconds"));
+
+    DEBUG_PRINT("Display Configuration: ");
+    DEBUG_PRINT("Matrix columns: " << config.get("matrixcols"));
+    DEBUG_PRINT("Matrix rows: " << config.get("matrixrows"));
+    DEBUG_PRINT("Matrix panels (chain): " << config.get("matrixchain_length"));
+    DEBUG_PRINT("Matirx rows (in parallel): " << config.get("matrixparallel"));
+    DEBUG_PRINT("Matrix hardware adapter: " << config.get("matrixhardware_mapping"));
+    DEBUG_PRINT("GPIO slowdown: " << config.get("gpio_slowdown"));
+    DEBUG_PRINT("First Line pixels from top of display: " << config.get("first_line_y"));
+    DEBUG_PRINT("Second Line pixels from top of display: " << config.get("second_line_y"));
+    DEBUG_PRINT("Third Line pixels from top of display: " << config.get("third_line_y"));
+    DEBUG_PRINT("Fourth Line pixels from top of display: " << config.get("fourth_line_y"));
+
+    DEBUG_PRINT("Starting display... ");
 }
 
 int main(int argc, char* argv[]) {
@@ -162,7 +186,7 @@ int main(int argc, char* argv[]) {
         
         TrainServiceParser parser;
         parser.updateData(api_data);
-        
+        DEBUG_PRINT("API initialised"); 
         // Create and run the display
         TrainServiceDisplay display(matrix, parser, apiClient, config);
         display_ptr = &display; // Set global pointer for signal handler

--- a/config.txt
+++ b/config.txt
@@ -11,6 +11,7 @@ platform=
 ShowCallingPointETD=Yes
 ShowMessages=Yes
 ShowPlatforms=Yes
+ShowLocation=Yes
 
 # API Configuration
 APIURL=
@@ -25,6 +26,7 @@ scroll_slowdown_sleep_ms=15
 refresh_interval_seconds=60
 third_line_refresh_seconds=10
 Message_Refresh_interval=20
+ETD_coach_refresh_seconds=4
 
 # Matrix hardware configuration
 matrixcols=128


### PR DESCRIPTION
Four functions added:

1. Departures now displayed in the order in which they're going to, erm, depart. Previously this was based on Scheduled Departure Time (std) only. Order is now based on std or Estimated Time of Departure (etd) - whichever is later.

2. Option to display the location (the 'from' field) at the bottom when the NRCC message isn't being shown

3. Moved departure time of the 1st departure to the top right of the display - alternating with the number of coaches

4. Calling points now have operator and number of coach information added.